### PR TITLE
main to dev

### DIFF
--- a/src/app/pages/manual-redemption/manual-redemption.component.ts
+++ b/src/app/pages/manual-redemption/manual-redemption.component.ts
@@ -163,12 +163,27 @@ export class ManualRedemptionComponent implements OnInit {
       return;
     }
 
-    // Validar que el monto sea mayor o igual al mínimo
-    if (this.originalAmount < this.minRedemptionAmount) {
+    // Convertir explícitamente a números para evitar comparaciones incorrectas
+    const amount = Number(this.originalAmount);
+    const minAmount = Number(this.minRedemptionAmount);
+
+    // Validar que el monto sea válido
+    if (isNaN(amount) || amount <= 0) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Monto inválido',
-        detail: `El monto debe ser al menos $${this.minRedemptionAmount.toFixed(2)}`,
+        detail: 'Por favor ingrese un monto válido mayor a $0.00',
+        life: 3000
+      });
+      return;
+    }
+
+    // Validar que el monto sea mayor o igual al mínimo
+    if (amount < minAmount) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Monto insuficiente',
+        detail: `El monto de compra debe ser al menos $${minAmount.toFixed(2)}. Ingresaste $${amount.toFixed(2)}`,
         life: 3000
       });
       return;

--- a/src/app/redeem/pages/redeem-page/redeem-page.component.ts
+++ b/src/app/redeem/pages/redeem-page/redeem-page.component.ts
@@ -211,12 +211,27 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
    * Confirma la redención con el monto ingresado
    */
   confirmRedemption(): void {
-    // Validar que el monto sea mayor o igual al mínimo
-    if (this.originalAmount < this.minRedemptionAmount) {
+    // Convertir explícitamente a números para evitar comparaciones incorrectas
+    const amount = Number(this.originalAmount);
+    const minAmount = Number(this.minRedemptionAmount);
+
+    // Validar que el monto sea válido
+    if (isNaN(amount) || amount <= 0) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Monto inválido',
-        detail: `El monto debe ser al menos $${this.minRedemptionAmount.toFixed(2)}`,
+        detail: 'Por favor ingrese un monto válido mayor a $0.00',
+        life: 3000
+      });
+      return;
+    }
+
+    // Validar que el monto sea mayor o igual al mínimo
+    if (amount < minAmount) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Monto insuficiente',
+        detail: `El monto de compra debe ser al menos $${minAmount.toFixed(2)}. Ingresaste $${amount.toFixed(2)}`,
         life: 3000
       });
       return;


### PR DESCRIPTION
This pull request improves the validation logic for redemption amounts in both the `ManualRedemptionComponent` and `RedeemPageComponent`. The changes ensure that the entered amount is explicitly converted to a number, is valid (not NaN or less than or equal to zero), and meets the minimum redemption requirement. User feedback messages have also been enhanced for clarity.

Validation logic improvements:

* Explicitly convert `originalAmount` and `minRedemptionAmount` to numbers before performing comparisons to prevent incorrect validations. [[1]](diffhunk://#diff-1ed3317e6c359f4e38f19c055acb4cbf594d5fb939b569f3883a2994193f16ccL166-R186) [[2]](diffhunk://#diff-ab6d528c99aa366a5014c044ac79d8857d0885a3e639f82539c70f08dd30e1a8L214-R234)
* Add a new validation step to check if the amount is a valid number and greater than zero, displaying a clear warning message if not. [[1]](diffhunk://#diff-1ed3317e6c359f4e38f19c055acb4cbf594d5fb939b569f3883a2994193f16ccL166-R186) [[2]](diffhunk://#diff-ab6d528c99aa366a5014c044ac79d8857d0885a3e639f82539c70f08dd30e1a8L214-R234)
* Update the minimum amount validation to use the converted numeric values and provide more informative feedback, including the entered amount in the message. [[1]](diffhunk://#diff-1ed3317e6c359f4e38f19c055acb4cbf594d5fb939b569f3883a2994193f16ccL166-R186) [[2]](diffhunk://#diff-ab6d528c99aa366a5014c044ac79d8857d0885a3e639f82539c70f08dd30e1a8L214-R234)