### PR TITLE
feat: update environment configuration and improve base URL retrieval…

### DIFF
--- a/src/app/pages/commons/environment.dev.ts
+++ b/src/app/pages/commons/environment.dev.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'https://lealtix-service.onrender.com/api'
+  apiUrl: 'https://lealtix-service.onrender.com/api',
+  landingPageBaseUrl: 'https://lealtix.com.mx/landing-page'
 };

--- a/src/app/pages/commons/environment.ts
+++ b/src/app/pages/commons/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080/api'
+  apiUrl: 'http://localhost:8080/api',
+  landingPageBaseUrl: 'http://localhost:4200/landing-page'
 };

--- a/src/app/pages/mi-pagina/mi-pagina.component.ts
+++ b/src/app/pages/mi-pagina/mi-pagina.component.ts
@@ -267,10 +267,20 @@ export class MiPaginaComponent implements OnInit {
    * Obtiene la URL base de la aplicación
    */
   private getBaseUrl(): string {
-    const baseUrl = environment.production
-      ? 'https://lealtix.com.mx/landing-page'
-      : 'http://localhost:4200/landing-page';
-    return baseUrl;
+    const cfg = environment as { landingPageBaseUrl?: string };
+
+    // 1) If explicit config exists, use it (trim trailing slash).
+    if (cfg.landingPageBaseUrl && cfg.landingPageBaseUrl.trim() !== '') {
+      return cfg.landingPageBaseUrl.replace(/\/+$/g, '');
+    }
+
+    // 2) Otherwise build from the current origin at runtime (avoids hardcoding localhost/prod).
+    if (typeof window !== 'undefined' && window.location && window.location.origin) {
+      return `${window.location.origin}/landing-page`;
+    }
+
+    // 3) Final fallback (shouldn't normally hit in browser environments).
+    return 'https://lealtix.com.mx/landing-page';
   }
 
   /**


### PR DESCRIPTION
This pull request updates how the application determines the base URL for the landing page, making it more flexible and environment-driven. The changes introduce a new `landingPageBaseUrl` property in the environment configuration files and refactor how the base URL is resolved in the `MiPaginaComponent` to prioritize configuration and runtime context.

**Environment configuration improvements:**

* Added a `landingPageBaseUrl` property to both `environment.ts` and `environment.dev.ts` to allow easy configuration of the landing page base URL for different environments. [[1]](diffhunk://#diff-bfa6e556aff425cad6e1f3c969159b75b36b19949e0d6a24d5b1ce56a36942aeL3-R4) [[2]](diffhunk://#diff-d9b045ae88e90ca9a4bcdbbfa78212ac39ca6f6786902d6ff3cec6d3c2a4cbbdL3-R4)

**Base URL resolution logic:**

* Refactored the `getBaseUrl` method in `mi-pagina.component.ts` to:
  - Prefer the `landingPageBaseUrl` from the environment config (trimming any trailing slashes).
  - Fall back to constructing the URL from the current browser origin if not set.
  - Use a hardcoded production URL as a last resort.… logic