### PR TITLE
Develop

### DIFF
--- a/src/app/pages/commons/environment.dev.ts
+++ b/src/app/pages/commons/environment.dev.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'https://lealtix-service.onrender.com/api'
+  apiUrl: 'https://lealtix-service.onrender.com/api',
+  landingPageBaseUrl: 'https://lealtix.com.mx/landing-page'
 };

--- a/src/app/pages/commons/environment.ts
+++ b/src/app/pages/commons/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080/api'
+  apiUrl: 'http://localhost:8080/api',
+  landingPageBaseUrl: 'http://localhost:4200/landing-page'
 };

--- a/src/app/pages/mi-pagina/mi-pagina.component.ts
+++ b/src/app/pages/mi-pagina/mi-pagina.component.ts
@@ -267,10 +267,20 @@ export class MiPaginaComponent implements OnInit {
    * Obtiene la URL base de la aplicación
    */
   private getBaseUrl(): string {
-    const baseUrl = environment.production
-      ? 'https://lealtix.com.mx/landing-page'
-      : 'http://localhost:4200/landing-page';
-    return baseUrl;
+    const cfg = environment as { landingPageBaseUrl?: string };
+
+    // 1) If explicit config exists, use it (trim trailing slash).
+    if (cfg.landingPageBaseUrl && cfg.landingPageBaseUrl.trim() !== '') {
+      return cfg.landingPageBaseUrl.replace(/\/+$/g, '');
+    }
+
+    // 2) Otherwise build from the current origin at runtime (avoids hardcoding localhost/prod).
+    if (typeof window !== 'undefined' && window.location && window.location.origin) {
+      return `${window.location.origin}/landing-page`;
+    }
+
+    // 3) Final fallback (shouldn't normally hit in browser environments).
+    return 'https://lealtix.com.mx/landing-page';
   }
 
   /**


### PR DESCRIPTION
This pull request improves the way the application determines the base URL for the landing page by introducing a configurable `landingPageBaseUrl` property in the environment files and updating the logic in `MiPaginaComponent` to use this property when available. This makes the application more flexible and easier to configure for different environments.

Configuration enhancements:

* Added a `landingPageBaseUrl` property to both `environment.ts` and `environment.dev.ts` to allow explicit configuration of the landing page URL for local development and production environments. [[1]](diffhunk://#diff-d9b045ae88e90ca9a4bcdbbfa78212ac39ca6f6786902d6ff3cec6d3c2a4cbbdL3-R4) [[2]](diffhunk://#diff-bfa6e556aff425cad6e1f3c969159b75b36b19949e0d6a24d5b1ce56a36942aeL3-R4)

Logic improvements in base URL resolution:

* Updated the `getBaseUrl` method in `mi-pagina.component.ts` to prioritize the new `landingPageBaseUrl` config, fall back to building the URL from the current window origin at runtime, and finally use a default value if necessary. This removes hardcoded URLs and improves maintainability.