### PR TITLE
refactor: update base URL retrieval logic in DashboardService

### DIFF
--- a/src/app/pages/dashboard/dashboard.service.ts
+++ b/src/app/pages/dashboard/dashboard.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { environment } from '@/pages/commons/environment';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
 import {
@@ -10,9 +11,25 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class DashboardService {
-  private base = 'http://localhost:8080/api/dashboard';
+  private get base(): string {
+    return `${this.getApiBaseUrl().replace(/\/+$/g, '')}/dashboard`;
+  }
 
   constructor(private http: HttpClient) {}
+
+  private getApiBaseUrl(): string {
+    const cfg = environment as { apiUrl?: string };
+
+    if (cfg.apiUrl && cfg.apiUrl.trim() !== '') {
+      return cfg.apiUrl.replace(/\/+$/g, '');
+    }
+
+    if (typeof window !== 'undefined' && window.location && window.location.origin) {
+      return `${window.location.origin}/api`;
+    }
+
+    return 'https://lealtix-service.onrender.com/api';
+  }
 
   private params(tenantId: number, from: string, to: string): HttpParams {
     return new HttpParams()


### PR DESCRIPTION
This pull request updates how the base API URL is determined in the `DashboardService` to better support different deployment environments and configurations. Instead of using a hardcoded localhost URL, the service now dynamically constructs the API base URL based on environment variables, browser location, or a default fallback.

API base URL configuration improvements:

* Changed the `base` property in `DashboardService` to a getter that constructs the URL dynamically, supporting environment configuration, browser location, and a fallback default.
* Added a new `getApiBaseUrl` private method to encapsulate the logic for selecting the appropriate base API URL.
* Imported the `environment` configuration to enable environment-based API URL selection.