### PR TITLE
Fix redeem qr

### DIFF
--- a/src/app/pages/campaigns/components/campaign-list/campaign-list.component.ts
+++ b/src/app/pages/campaigns/components/campaign-list/campaign-list.component.ts
@@ -237,14 +237,13 @@ export class CampaignListComponent implements OnInit {
                 }
                 this.loadCampaigns();
                 this.checkBannerConditions();
+                // Check if we should show welcome confetti after data loads
+                setTimeout(() => this.checkForWelcomeConfetti(), 500);
             },
             error: (error) => {
                 console.error('No tenant found:');
             }
         });
-
-        // Check if we should show welcome confetti
-        this.checkForWelcomeConfetti();
     }
 
     private loadCampaigns(): void {
@@ -258,9 +257,6 @@ export class CampaignListComponent implements OnInit {
                     // También actualizar la lista de campañas sin validación para compatibilidad
                     this.campaigns.set(campaignsWithValidation.map(item => item.campaign));
                     this.loading.set(false);
-
-                    // Check if we should show confetti after campaigns loaded
-                    this.checkForWelcomeConfetti();
                 },
                 error: (error) => {
                     console.error('Error loading campaigns:', error);

--- a/src/app/pages/campaigns/components/reward-form/reward-form.component.ts
+++ b/src/app/pages/campaigns/components/reward-form/reward-form.component.ts
@@ -323,6 +323,14 @@ export class RewardFormComponent implements OnInit, OnChanges {
     return this.rewardForm.get('rewardType')?.value;
   }
 
+  /**
+   * Método público para obtener el rewardType seleccionado actualmente
+   * Útil para obtener el valor incluso cuando es NONE (que no retorna reward data)
+   */
+  public getSelectedRewardType(): RewardType | null {
+    return this.rewardForm.get('rewardType')?.value;
+  }
+
   get showNumericValue(): boolean {
     return this.selectedRewardType === RewardType.PERCENT_DISCOUNT ||
            this.selectedRewardType === RewardType.FIXED_AMOUNT;

--- a/src/app/pages/redeem/pages/redeem-page/redeem-page.component.html
+++ b/src/app/pages/redeem/pages/redeem-page/redeem-page.component.html
@@ -461,8 +461,8 @@
       <p-inputNumber
         id="originalAmount"
         [(ngModel)]="originalAmount"
-        mode="currency"
-        currency="MXN"
+        mode="decimal"
+        prefix="$"
         locale="es-MX"
         [minFractionDigits]="2"
         [maxFractionDigits]="2"
@@ -470,13 +470,13 @@
         styleClass="w-full"
         inputStyleClass="w-full">
       </p-inputNumber>
-      <small class="text-red-600 mt-2 block" *ngIf="originalAmount > 0 && originalAmount < minRedemptionAmount">
+      <small class="text-red-600 mt-2 block" *ngIf="(originalAmount ?? 0) > 0 && (originalAmount ?? 0) < minRedemptionAmount">
         <i class="pi pi-exclamation-triangle"></i>
         El monto debe ser al menos ${{ minRedemptionAmount.toFixed(2) }} para usar este cupón
       </small>
     </div>
 
-    <div class="preview-info" *ngIf="originalAmount >= minRedemptionAmount && rewardData">
+    <div class="preview-info" *ngIf="(originalAmount ?? 0) >= minRedemptionAmount && rewardData">
       <p-divider></p-divider>
       <div class="preview-row">
         <span class="preview-label">Tipo de descuento:</span>
@@ -492,22 +492,22 @@
       <div class="preview-row">
         <span class="preview-label">Descuento aplicado:</span>
         <span class="preview-value discount-preview">
-          <span *ngIf="rewardData.rewardType === 'PERCENT_DISCOUNT'">
-            -${{ (originalAmount * rewardData.numericValue / 100).toFixed(2) }}
+            <span *ngIf="rewardData.rewardType === 'PERCENT_DISCOUNT'">
+            -${{ ((originalAmount ?? 0) * rewardData.numericValue / 100).toFixed(2) }}
           </span>
           <span *ngIf="rewardData.rewardType === 'FIXED_AMOUNT'">
-            -${{ Math.min(rewardData.numericValue, originalAmount).toFixed(2) }}
+            -${{ Math.min(rewardData.numericValue, (originalAmount ?? 0)).toFixed(2) }}
           </span>
         </span>
       </div>
       <div class="preview-row final">
         <span class="preview-label"><strong>Total a pagar:</strong></span>
         <span class="preview-value final-preview">
-          <span *ngIf="rewardData.rewardType === 'PERCENT_DISCOUNT'">
-            <strong>${{ (originalAmount - (originalAmount * rewardData.numericValue / 100)).toFixed(2) }}</strong>
+            <span *ngIf="rewardData.rewardType === 'PERCENT_DISCOUNT'">
+            <strong>${{ ((originalAmount ?? 0) - ((originalAmount ?? 0) * rewardData.numericValue / 100)).toFixed(2) }}</strong>
           </span>
           <span *ngIf="rewardData.rewardType === 'FIXED_AMOUNT'">
-            <strong>${{ (originalAmount - Math.min(rewardData.numericValue, originalAmount)).toFixed(2) }}</strong>
+            <strong>${{ ((originalAmount ?? 0) - Math.min(rewardData.numericValue, (originalAmount ?? 0))).toFixed(2) }}</strong>
           </span>
         </span>
       </div>

--- a/src/app/pages/redeem/pages/redeem-page/redeem-page.component.ts
+++ b/src/app/pages/redeem/pages/redeem-page/redeem-page.component.ts
@@ -66,7 +66,7 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
 
   // Dialog para solicitar monto
   showAmountDialog: boolean = false;
-  originalAmount: number = 0;
+  originalAmount: number | null = null;
   minRedemptionAmount: number = 0;
 
   // Reward data y cálculos de descuento
@@ -268,7 +268,7 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
     // Si rewardData ya está cargado, usarlo directamente
     if (this.rewardData) {
       this.minRedemptionAmount = this.rewardData.minPurchaseAmount || 0;
-      this.originalAmount = 0;
+      this.originalAmount = null;
 
       // Validar límite de uso
       if (this.rewardData.usageCount >= this.rewardData.usageLimit) {
@@ -305,7 +305,7 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
         next: (reward: any) => {
           this.rewardData = reward;
           this.minRedemptionAmount = reward.minPurchaseAmount || 0;
-          this.originalAmount = 0;
+          this.originalAmount = null;
 
           // Validar límite de uso
           if (this.rewardData && this.rewardData.usageCount >= this.rewardData.usageLimit) {
@@ -324,7 +324,7 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
           console.error('Error obteniendo reward:', error);
           // Si no hay reward definido, usar valores por defecto
           this.minRedemptionAmount = this.validationData?.minRedemptionAmount || this.validationData?.minPurchaseAmount || 0;
-          this.originalAmount = 0;
+          this.originalAmount = null;
           this.showAmountDialog = true;
         }
       });
@@ -335,6 +335,7 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
    */
   confirmRedemption(): void {
     // Convertir explícitamente a números para evitar comparaciones incorrectas
+    debugger;
     const amount = Number(this.originalAmount);
     const minAmount = Number(this.minRedemptionAmount);
 
@@ -425,43 +426,14 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
    */
   cancelAmountDialog(): void {
     this.showAmountDialog = false;
-    this.originalAmount = 0;
+    this.originalAmount = null;
   }
 
   /**
    * Ejecuta la redención del cupón
    */
   private redeemCoupon(): void {
-    // Validaciones previas: asegurar que el monto ingresado es válido
-    const amount = Number(this.originalAmount);
-    const minAmount = Number(this.minRedemptionAmount || this.validationData?.minPurchaseAmount || 0);
-
-    if (isNaN(amount) || amount <= 0) {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Monto inválido',
-        detail: 'Por favor ingresa un monto de compra válido',
-        life: 4000
-      });
-      // Mantener la vista en estado válido y reabrir diálogo si corresponde
-      this.isRedeeming = false;
-      this.pageState = 'valid';
-      this.showAmountDialog = true;
-      return;
-    }
-
-    if (amount < minAmount) {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Monto insuficiente',
-        detail: `Este cupón requiere una compra mínima de $${minAmount.toFixed(2)}`,
-        life: 4000
-      });
-      this.isRedeeming = false;
-      this.pageState = 'valid';
-      this.showAmountDialog = true;
-      return;
-    }
+    debugger;
 
     this.isRedeeming = true;
     this.pageState = 'redeeming';
@@ -471,7 +443,7 @@ export class RedeemPageComponent implements OnInit, OnDestroy {
     const request: RedemptionRequest = {
       redeemedBy: currentUser?.email || currentUser?.userEmail || 'unknown',
       channel: RedemptionChannel.QR_WEB,
-      originalAmount: this.originalAmount,
+      originalAmount: this.originalAmount ?? undefined,
       location: 'Web Dashboard',
       metadata: JSON.stringify({
         device: this.getDeviceType(),


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to campaign creation/editing and the coupon redemption flow. The main highlights include more flexible campaign validation (especially for "promotion only" campaigns), improved handling of reward types, and enhanced robustness for the redemption amount input. Additionally, there are minor UI/UX improvements and code cleanups.

**Campaign Creation & Editing**

* Relaxed validation for editing campaigns: Only title and date fields are required for editing, allowing campaigns without a benefit ("Sin beneficio").
* The `description` field is now optional in the campaign form, allowing drafts or edits without a description.
* The selected reward type now determines if the reward payload is included; if "NONE" is selected, no reward is sent in the update request. [[1]](diffhunk://#diff-1c601eb3862e31637c2a3380246848a433d32584be97d6386424e0c74416b017R531-R550) [[2]](diffhunk://#diff-1c601eb3862e31637c2a3380246848a433d32584be97d6386424e0c74416b017L538-L550) [[3]](diffhunk://#diff-1c601eb3862e31637c2a3380246848a433d32584be97d6386424e0c74416b017R582)
* After a successful campaign update, the user is redirected to the campaign list after a short delay.
* Added a public method `getSelectedRewardType()` in `RewardFormComponent` for more reliable reward type checks.

**Campaign List UI**

* The welcome confetti is now shown after campaign data loads (with a short delay), preventing premature display before data is ready. [[1]](diffhunk://#diff-8b17c1cd9b16b3ee9edb0677b4a8cbc2cdeae4f76d4fb45de9e905e4beb3a87fR240-L247) [[2]](diffhunk://#diff-8b17c1cd9b16b3ee9edb0677b4a8cbc2cdeae4f76d4fb45de9e905e4beb3a87fL261-L263)

**Redemption Flow Improvements**

* The `originalAmount` is now nullable throughout the redemption flow, preventing issues with zero values and improving input handling. [[1]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddL69-R69) [[2]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddL271-R271) [[3]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddL308-R308) [[4]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddL327-R327) [[5]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddL428-R436)
* All UI and calculation logic in the redemption page now safely handle `originalAmount` being `null`, avoiding incorrect calculations or warnings. [[1]](diffhunk://#diff-305f7598a00a91cdd6def6c4c8f4c2f7af5d86b1ed49f5b423c8379f5e56861aL464-R479) [[2]](diffhunk://#diff-305f7598a00a91cdd6def6c4c8f4c2f7af5d86b1ed49f5b423c8379f5e56861aL496-R510)
* The input field for the amount now uses decimal mode with a currency prefix, improving user experience.
* When sending the redemption request, `originalAmount` is omitted if not set.

**Other**

* Added a `debugger;` statement in the redemption confirmation and redeem methods, likely for development troubleshooting. [[1]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddR338) [[2]](diffhunk://#diff-3a9c70f508ce12f5edd4304bdf77cec3b9aa50e2fb5d3a2cc55bd54848cfb2ddL428-R436)
* Updated imports to include `RewardType` where needed.