### PR TITLE
fix(landing-editor): make slogan field optional in form validation

### DIFF
--- a/src/app/pages/admin-page/landing-editor.component.ts
+++ b/src/app/pages/admin-page/landing-editor.component.ts
@@ -76,7 +76,7 @@ export class LandingEditorComponent implements OnInit {
         this.landingForm = this.fb.group({
             logo: [null],
             businessName: ['', Validators.required],
-            slogan: ['', Validators.required],
+            slogan: [''],
             history: ['', Validators.required],
             vision: ['', Validators.required],
             address: ['', Validators.required],

--- a/src/app/pages/mi-pagina/mi-pagina.component.html
+++ b/src/app/pages/mi-pagina/mi-pagina.component.html
@@ -226,18 +226,6 @@
             <i class="pi pi-print mr-2"></i>
             <span>Ver Menú para Imprimir</span>
           </a>
-
-          <button
-            type="button"
-            pButton
-            label="Exportar PDF Directo"
-            icon="pi pi-file-pdf"
-            severity="danger"
-            class="p-button-outlined"
-            (click)="navigateToMenuPrintAndExport()"
-            pTooltip="Exporta el menú a PDF automáticamente"
-            tooltipPosition="top"
-          ></button>
         </div>
 
         <small class="block" style="color: #94a3b8;">

--- a/src/app/pages/products-menu/products-menu.component.ts
+++ b/src/app/pages/products-menu/products-menu.component.ts
@@ -160,7 +160,7 @@ export class ProductMenuComponent implements OnInit {
         this.productForm = this.fb.group({
             id: [null],
             name: ['', Validators.required],
-            description: ['', Validators.required],
+            description: [''],
             price: [null, Validators.required],
             img_url: [''],
             productImage: [null], // store actual File/Blob for upload
@@ -332,10 +332,10 @@ export class ProductMenuComponent implements OnInit {
 
         const filename = `lealtix_plantilla_menu_productos_${slug}.csv`;
 
-        // CSV content with proper headers
-        const csvContent = `Categoria,Descripcion categoria,Nombre Producto,Descripcion Producto,Precio,Estatus
-,,,,
-,,,,`;
+        // CSV content with proper headers (without 'Estatus')
+        const csvContent = `Categoria,Descripcion categoria,Nombre Producto,Descripcion Producto,Precio
+    ,,,,
+    ,,,,`;
 
         // Create CSV blob with UTF-8 BOM for Excel compatibility
         const BOM = '\uFEFF';
@@ -441,7 +441,7 @@ export class ProductMenuComponent implements OnInit {
             return;
         }
 
-        const expectedColumns = ['Categoria', 'Descripcion categoria', 'Nombre Producto', 'Descripcion Producto', 'Precio', 'Estatus'];
+        const expectedColumns = ['Categoria', 'Descripcion categoria', 'Nombre Producto', 'Descripcion Producto', 'Precio'];
 
         const firstRow = rows[0];
         if (!firstRow) {
@@ -575,6 +575,11 @@ export class ProductMenuComponent implements OnInit {
             this.stopLoading();
             return;
         }
+
+        // Ensure `isActive` is always true by default for each product
+        productsToCreate.forEach(p => {
+            p.isActive = true;
+        });
 
         const payload = {
             tenantId: this.tenantId,


### PR DESCRIPTION
This pull request introduces several improvements and minor adjustments to form validation, CSV import/export functionality, and product handling in the admin and product menu pages. The main changes center around relaxing validation requirements, updating the CSV format for product menus, and ensuring consistent product activation status.

**Form Validation Adjustments:**
- The `slogan` field in the `LandingEditorComponent` and the `description` field in the `ProductMenuComponent` are no longer required, making these fields optional during form submission. [[1]](diffhunk://#diff-9a502c52fa6e969dbeaca245dfa5ddb0b98ea062c9d75c8faf228adaa89b770dL79-R79) [[2]](diffhunk://#diff-bf16f7aec7230872f9474d6a17d2eb9094203bf08f1d57dd0d6694b463821791L163-R163)

**CSV Import/Export Updates:**
- The CSV template and import logic for product menus have been updated to remove the `Estatus` column, both in the exported file and in the expected columns during import. [[1]](diffhunk://#diff-bf16f7aec7230872f9474d6a17d2eb9094203bf08f1d57dd0d6694b463821791L335-R336) [[2]](diffhunk://#diff-bf16f7aec7230872f9474d6a17d2eb9094203bf08f1d57dd0d6694b463821791L444-R444)

**Product Handling Improvements:**
- When importing products from CSV, each product's `isActive` property is now explicitly set to `true` by default, ensuring all imported products are activated.

**UI Adjustments:**
- The "Exportar PDF Directo" button has been removed from the `mi-pagina.component.html` page, simplifying the user interface.refactor(products-menu): update CSV export format and remove 'Estatus' column
refactor(products-menu): ensure products are active by default
refactor(mi-pagina): remove direct PDF export button from menu section