### PR TITLE
feat(campaign-form): update description handling for promotional bene…

### DIFF
--- a/src/app/pages/campaigns/components/campaign-form/campaign-form.component.html
+++ b/src/app/pages/campaigns/components/campaign-form/campaign-form.component.html
@@ -74,18 +74,7 @@
         </div>
       </div>
 
-      <div class="col-12">
-        <div class="field">
-          <label for="description" class="font-semibold text-gray-800 mb-2">Descripción</label>
-          <textarea
-            id="description"
-            formControlName="description"
-            rows="3"
-            placeholder="Describe la campaña"
-            class="rounded border border-gray-300 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition text-gray-900 w-full"
-          ></textarea>
-        </div>
-      </div>
+      <!-- La descripción del reward/beneficio se muestra en la sección de Promoción cuando aplica -->
 
       <!-- Promoción -->
       <div class="col-12">
@@ -128,6 +117,22 @@
         <div class="field">
           <label for="callToAction" class="font-semibold text-gray-800 mb-2">Call to Action</label>
           <input id="callToAction" pInputText formControlName="callToAction" placeholder="Ej: ¡Aprovecha ahora!" class="rounded border border-gray-300 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition text-gray-900 w-full" />
+        </div>
+      </div>
+
+      <!-- Descripción del beneficio (solo para 'Ninguno (Solo Promoción)') -->
+      <div class="col-12" *ngIf="isPromoTypeCustom()">
+        <div class="field">
+          <label for="descriptionReward" class="font-semibold text-gray-800 mb-2">Descripción del Beneficio <span class="text-red-500">*</span></label>
+          <textarea
+            id="descriptionReward"
+            formControlName="description"
+            rows="3"
+            placeholder="Describe qué estás promocionando"
+            class="rounded border border-gray-300 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition text-gray-900 w-full"
+          ></textarea>
+          <small *ngIf="campaignForm.get('description')?.errors?.['required'] && campaignForm.get('description')?.touched" class="text-red-600 text-sm block">La descripción del beneficio es requerida</small>
+          <small *ngIf="campaignForm.get('description')?.errors?.['minlength'] && campaignForm.get('description')?.touched" class="text-red-600 text-sm block">La descripción debe tener al menos 3 caracteres</small>
         </div>
       </div>
 

--- a/src/app/pages/campaigns/components/campaign-form/campaign-form.component.ts
+++ b/src/app/pages/campaigns/components/campaign-form/campaign-form.component.ts
@@ -80,9 +80,7 @@ export class CampaignFormComponent implements OnInit {
     { label: 'Descuento porcentual', value: PromoType.DISCOUNT },
     { label: 'Descuento por monto', value: PromoType.AMOUNT },
     { label: 'Compra uno lleva otro', value: PromoType.BOGO },
-    { label: 'Artículo gratuito', value: PromoType.FREE_ITEM },
-    { label: 'Promoción personalizada', value: PromoType.CUSTOM }
-  ];
+    { label: 'Artículo gratuito', value: PromoType.FREE_ITEM }  ];
 
   statusOptions = [
     { label: 'Borrador', value: CampaignStatus.DRAFT },
@@ -226,6 +224,8 @@ export class CampaignFormComponent implements OnInit {
       status: campaign.status,
       isAutomatic: campaign.isAutomatic
     });
+    // Aplicar validadores dependientes del promoType tras cargar
+    this.onPromoTypeChange();
   }
 
   private setupImagePreview(): void {
@@ -254,6 +254,7 @@ export class CampaignFormComponent implements OnInit {
   onPromoTypeChange(): void {
     const promoType = this.campaignForm.get('promoType')?.value;
     const promoValueControl = this.campaignForm.get('promoValue');
+    const descriptionControl = this.campaignForm.get('description');
 
     // Reset promo value when type changes
     promoValueControl?.setValue('');
@@ -265,12 +266,24 @@ export class CampaignFormComponent implements OnInit {
       promoValueControl?.clearValidators();
     }
 
+    // Si es 'Solo Promoción' (CUSTOM) entonces la descripción del reward es requerida
+    if (promoType === PromoType.CUSTOM) {
+      descriptionControl?.setValidators([Validators.required, Validators.minLength(3)]);
+    } else {
+      descriptionControl?.clearValidators();
+    }
+
     promoValueControl?.updateValueAndValidity();
+    descriptionControl?.updateValueAndValidity();
   }
 
   shouldShowPromoValue(): boolean {
     const promoType = this.campaignForm.get('promoType')?.value;
     return promoType === PromoType.DISCOUNT || promoType === PromoType.AMOUNT || promoType === PromoType.CUSTOM;
+  }
+
+  isPromoTypeCustom(): boolean {
+    return this.campaignForm.get('promoType')?.value === PromoType.CUSTOM;
   }
 
   getPromoValueLabel(): string {

--- a/src/app/pages/campaigns/components/reward-form/reward-form.component.ts
+++ b/src/app/pages/campaigns/components/reward-form/reward-form.component.ts
@@ -55,13 +55,9 @@ export class RewardFormComponent implements OnInit, OnChanges {
   private lastLoadedTenantId: number | null = null;
   private isUpdatingValidators = false;
   rewardTypes = [
-    { label: 'Ninguno (solo promoción)', value: RewardType.NONE },
     { label: 'Descuento porcentual', value: RewardType.PERCENT_DISCOUNT },
     { label: 'Monto fijo', value: RewardType.FIXED_AMOUNT },
-    // { label: 'Producto gratis', value: RewardType.FREE_PRODUCT }, // TODO: Fix TreeSelect integration
-    // Temporarily removed: BUY_X_GET_Y and CUSTOM
-    // { label: 'Compra X lleva Y', value: RewardType.BUY_X_GET_Y },
-    // { label: 'Personalizado', value: RewardType.CUSTOM }
+    { label: 'Personalizado / Solo promoción', value: RewardType.CUSTOM }
   ];
 
   isSubmitting = false;


### PR DESCRIPTION
This pull request updates the campaign creation form to clarify and improve how the description field is handled, especially for custom promotions. The main changes involve moving the description field to the promotion section (when relevant), updating form validation logic, and adjusting option labels for clarity.

**Form structure and validation improvements:**

* The general campaign description field was removed from the "Información Básica" section and is now shown only in the "Configuración de Promoción" section when the promotion type is "Ninguno (Solo Promoción)" (custom promotion). [[1]](diffhunk://#diff-672db29393d55354347eb34e92488ee5e2b2072fb6b0c6c2a1c7b0e4ed362126L77-R77) [[2]](diffhunk://#diff-672db29393d55354347eb34e92488ee5e2b2072fb6b0c6c2a1c7b0e4ed362126R123-R138)
* The description field is now required and must have at least 3 characters when the promotion type is custom; validators are dynamically applied based on the selected promotion type. [[1]](diffhunk://#diff-7ed1523f4017cd18eb7d18aebe381e67b46f52bb46a1a5de6d79f666d13148acR257) [[2]](diffhunk://#diff-7ed1523f4017cd18eb7d18aebe381e67b46f52bb46a1a5de6d79f666d13148acR269-R288)
* The form logic was updated to apply the correct validators when loading an existing campaign.

**Option and label adjustments:**

* The "Promoción personalizada" option was removed from the promotion type dropdown in `CampaignFormComponent`, leaving only standard types.
* In `RewardFormComponent`, the reward type options were updated to combine "Personalizado" and "Solo promoción" into a single option for clarity.

**Helper methods:**

* Added the `isPromoTypeCustom()` helper method to simplify template logic for conditionally displaying the description field.…fits and adjust validators